### PR TITLE
Allow manipulating the fake response

### DIFF
--- a/src/Gateway/Request/AuthenticateSPRequest.php
+++ b/src/Gateway/Request/AuthenticateSPRequest.php
@@ -14,9 +14,9 @@ use stdClass;
 class AuthenticateSPRequest
 {
     /**
-     * @var string
+     * @var ?string
      */
-    private string $CustomerReference;
+    private ?string $CustomerReference;
 
     /**
      * @var stdClass
@@ -111,19 +111,19 @@ class AuthenticateSPRequest
     }
 
     /**
-     * @return string
+     * @return ?string
      */
-    public function getCustomerReference(): string
+    public function getCustomerReference(): ?string
     {
         return $this->CustomerReference;
     }
 
     /**
-     * @param string $CustomerReference
+     * @param ?string $CustomerReference
      *
      * @return AuthenticateSPRequest
      */
-    public function setCustomerReference(string $CustomerReference): AuthenticateSPRequest
+    public function setCustomerReference(?string $CustomerReference): AuthenticateSPRequest
     {
         $this->CustomerReference = $CustomerReference;
 

--- a/src/Service/GlobalAuthenticationService.php
+++ b/src/Service/GlobalAuthenticationService.php
@@ -214,6 +214,14 @@ class GlobalAuthenticationService extends ID3BaseService
     }
 
     /**
+     * @param GlobalAuthenticationGateway $gateway
+     */
+    public function setGateway(GlobalAuthenticationGateway $gateway): void
+    {
+        $this->gateway = $gateway;
+    }
+
+    /**
      * @return array
      */
     public function getSoapOptions(): array

--- a/src/Service/GlobalAuthenticationService.php
+++ b/src/Service/GlobalAuthenticationService.php
@@ -18,11 +18,11 @@ class GlobalAuthenticationService extends ID3BaseService
     private GlobalAuthenticationGateway $gateway;
 
     /**
-     * @var string The Profile ID to be used when verifying identities via->verifyIdentity().
+     * @var ?string The Profile ID to be used when verifying identities via->verifyIdentity().
      *
      * @see self::setProfileId()
      */
-    private string $profileId = '';
+    private ?string $profileId = null;
 
     /**
      * @var int The version of the Profile ID to be used when verifying identities via->verifyIdentity().
@@ -99,7 +99,7 @@ class GlobalAuthenticationService extends ID3BaseService
 
         $gateway = $this->getGateway();
 
-        if (!$this->profileId) {
+        if ($this->profileId === null) {
             $error = 'An ID3global Profile ID must be set by calling setProfileId() before calling verifyIdentity().';
 
             throw new LogicException($error);

--- a/src/Stubs/Gateway/GlobalAuthenticationGatewayFake.php
+++ b/src/Stubs/Gateway/GlobalAuthenticationGatewayFake.php
@@ -25,18 +25,51 @@ class GlobalAuthenticationGatewayFake extends GlobalAuthenticationGateway
      */
     const IDENTITY_BAND_ALERT = 'ALERT';
 
+    private string $bandText = self::IDENTITY_BAND_PASS;
+
+    private int $score = 3000;
+
     public function __construct($username, $password, $soapClientOptions = [], $usePilotSite = false)
     {
         parent::__construct($username, $password, $soapClientOptions, $usePilotSite);
     }
 
-    public function AuthenticateSP($profileID, $profileVersion, $customerReference, Identity $identity)
+    /**
+     * @param string $bandText
+     *
+     * @return GlobalAuthenticationGatewayFake
+     */
+    public function setBandText(string $bandText): GlobalAuthenticationGatewayFake
     {
-        $bandText = self::IDENTITY_BAND_PASS;
+        $this->bandText = $bandText;
 
+        return $this;
+    }
+
+    /**
+     * @param int $score
+     *
+     * @return GlobalAuthenticationGatewayFake
+     */
+    public function setScore(int $score): GlobalAuthenticationGatewayFake
+    {
+        $this->score = $score;
+
+        return $this;
+    }
+
+    public function AuthenticateSP(string $profileID, int $profileVersion, ?string $customerReference, Identity $identity)
+    {
         return unserialize(sprintf(
-            'O:8:"stdClass":1:{s:20:"AuthenticateSPResult";O:8:"stdClass":12:{s:16:"AuthenticationID";s:36:"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";s:9:"Timestamp";s:33:"2016-01-01T00:00:00.0000000+01:00";s:11:"CustomerRef";s:1:"x";s:9:"ProfileID";s:36:"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";s:11:"ProfileName";s:15:"Default Profile";s:14:"ProfileVersion";i:1;s:15:"ProfileRevision";i:1;s:12:"ProfileState";s:9:"Effective";s:11:"ResultCodes";O:8:"stdClass":1:{s:26:"GlobalItemCheckResultCodes";a:0:{}}s:5:"Score";i:3000;s:8:"BandText";s:4:"%s";s:7:"Country";s:11:"New Zealand";}}',
-            $bandText
+            'O:8:"stdClass":1:{s:20:"AuthenticateSPResult";O:8:"stdClass":12:{s:16:"AuthenticationID";s:36:"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";s:9:"Timestamp";s:33:"2016-01-01T00:00:00.0000000+01:00";s:11:"CustomerRef";s:%d:"%s";s:9:"ProfileID";s:%d:"%s";s:11:"ProfileName";s:15:"Default Profile";s:14:"ProfileVersion";i:%d;s:15:"ProfileRevision";i:1;s:12:"ProfileState";s:9:"Effective";s:11:"ResultCodes";O:8:"stdClass":1:{s:26:"GlobalItemCheckResultCodes";a:0:{}}s:5:"Score";i:%d;s:8:"BandText";s:%d:"%s";s:7:"Country";s:11:"New Zealand";}}',
+            strlen($customerReference),
+            $customerReference,
+            strlen($profileID),
+            $profileID,
+            $profileVersion,
+            $this->score,
+            strlen($this->bandText),
+            $this->bandText
         ));
     }
 }

--- a/tests/Service/GlobalAuthenticationServiceTest.php
+++ b/tests/Service/GlobalAuthenticationServiceTest.php
@@ -71,10 +71,10 @@ class GlobalAuthenticationServiceTest extends TestCase
      * @dataProvider fakeResponses
      *
      * @param string $profileId
-     * @param int $profileVersion
+     * @param int    $profileVersion
      * @param string $customerReference
      * @param string $bandText
-     * @param int $score
+     * @param int    $score
      *
      * @throws IdentityVerificationFailureException
      */

--- a/tests/Service/GlobalAuthenticationServiceTest.php
+++ b/tests/Service/GlobalAuthenticationServiceTest.php
@@ -120,7 +120,7 @@ class GlobalAuthenticationServiceTest extends TestCase
     {
         return [
             ['profile-id', 1, 'customer-1', GlobalAuthenticationGatewayFake::IDENTITY_BAND_ALERT, 20000],
-            ['profile-id-2', 0, 'customer-2', GlobalAuthenticationGatewayFake::IDENTITY_BAND_REFER, 500],
+            ['', 0, '', GlobalAuthenticationGatewayFake::IDENTITY_BAND_REFER, 500],
         ];
     }
 }


### PR DESCRIPTION
You can now configure the `GlobalAuthenticationGatewayFake` class to return responses other than a `PASS` response.