### PR TITLE
Add phpcs linting and code coverage via codecov.io

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,10 +1,9 @@
-name: PHP Composer
+name: Run PHP Parallel Lint, PHP CodeSniffer, and PHPUnit tests
 
 on: [ push, pull_request ]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -25,8 +24,20 @@ jobs:
     - name: Install dependencies
       run: composer install --prefer-dist --no-progress
 
-    # Add a test script to composer.json, for instance: "test": "vendor/bin/phpunit"
-    # Docs: https://getcomposer.org/doc/articles/scripts.md
+    - name: Run PHP Parallel Lint
+      run: vendor/bin/parallel-lint . --exclude vendor
+
+    - name: Run phpcs
+      run: vendor/bin/phpcs -s
 
     - name: Run test suite
-      run: vendor/bin/phpunit
+      run: XDEBUG_MODE=coverage vendor/bin/phpunit
+
+    - name: Upload code coverage to Codecov
+      uses: codecov/codecov-action@v2
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        directory: ./.artifacts
+        fail_ci_if_error: true
+        flags: phpunit
+        verbose: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
+/.artifacts
 /.idea
+/.phpunit.result.cache
+/composer.lock
 /vendor
-.phpunit.result.cache
-*.lock

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,10 @@
     },
 
     "require-dev": {
-        "phpunit/phpunit": "^9.5.8"
+        "phpunit/phpunit": "^9.5.8",
+        "slevomat/coding-standard": "^7.0",
+        "php-parallel-lint/php-parallel-lint": "^1.3",
+        "php-parallel-lint/php-console-highlighter": "^0.5.0"
     },
 
     "authors": [

--- a/docs/full-code-example.md
+++ b/docs/full-code-example.md
@@ -1,0 +1,102 @@
+# id3global-service
+
+## Key classes
+
+**Core services:**
+* `ID3Global\Service\GlobalAuthenticationService`: The core service class used to request identity verification
+* `ID3Global\Gateway\GlobalAuthenticationGateway`: The internal gateway class that communicates (via SOAP) with ID3global
+
+**Identity information:**
+* `ID3Global\Identity\Identity`: The base class for a single person's identity
+* `ID3Global\Identity\PersonalDetails`: A class to capture core identity information (name, date of birth etc)
+* `ID3Global\Identity\ContactDetails\PhoneNumber`: Include a single phone number (can be used for landline, mobile etc)
+
+**Address specification:**
+* `ID3Global\Identity\Address\FreeFormatAddress`: A 'free-form' address where individual address fields aren't specified
+* `ID3Global\Identity\Address\FixedFormatAddress`: A fixed address format (e.g. fields for street, city, subcity etc)
+
+**Additional identity documents:**
+* `ID3Global\Identity\Documents\DocumentContainer`: Class that contains all below documents
+* `ID3Global\Identity\Documents\InternationalPassport`: Contains details about a passport
+* `ID3Global\Identity\Documents\NZ\DrivingLicence`: Contains details about a New Zealand drivers licence
+
+## Full code example
+
+Below is a complete example of how to utilise this module, configuring personal details, a single address, multiple phone numbers and a passport.
+
+Once the identity is created, we create and submit it to the `GlobalAuthenticationService`.
+
+In the below example, we enable the 'pilot' site, which is the ID3global test environment. Leave this line out to query production (this will incur costs).
+
+Finally, please review the comment below regarding the value of `$validIdentityBandText` - it's critically important that this is correct.
+
+```php
+$birthday = DateTime::createFromFormat('Y-m-d', '1922-08-20');
+$personalDetails = new \ID3Global\Identity\PersonalDetails();
+$personalDetails
+    ->setTitle('Mr')
+    ->setForeName('Dworkin')
+    ->setMiddleName('John')
+    ->setSurname('Barimen')
+    ->setGender('male')
+    ->setDateOfBirth($birthday);
+
+$currentAddress = new \ID3Global\Identity\Address\FreeFormatAddress();
+$currentAddress
+    ->setCountry('New Zealand')
+    ->setPostCode('90210')
+    // You can set up to 8 address lines if required using ->setAddressLine3(), ->setAddressLine8() etc.
+    ->setAddressLine1('Dungeon 1')
+    ->setAddressLine2('Courts of Amber');
+
+$addressContainer = new \ID3Global\Identity\Address\AddressContainer();
+$addressContainer->setCurrentAddress($currentAddress);
+
+$phone = new \ID3Global\Identity\ContactDetails\PhoneNumber();
+$phone->setNumber(1234567890);
+
+$contactDetails = new \ID3Global\Identity\ContactDetails();
+$contactDetails
+    ->setLandTelephone($phone)
+    ->setMobileTelephone($phone)
+    ->setWorkTelephone($phone)
+    ->setEmail('dworkin@thepattern.net');
+
+$internationalPassport = new \ID3Global\Identity\Documents\InternationalPassport();
+$documentContainer = new \ID3Global\Identity\Documents\DocumentContainer();
+$documentContainer->addIdentityDocument(new \ID3Global\Identity\Documents\NZ\DrivingLicence(), 'New Zealand');
+
+/**
+ * $result will be a string representing the 'BandText' as returned by the ID3global API. By default, this may be a word
+ * like 'PASS', 'REFER' or 'ALERT' but could also be any string value e.g. 'Name, Address and DOB Match'. The exact
+ * string returned is entirely dependent on how the profile is configured within ID3global, and can vary if you adjust
+ * the profile id and profile version.
+ *
+ * It is up to your implementation how these are handled. Note that generally there is only a single value that
+ * represents an identity that has passed the necessary verification, and multiple BandTexts that represent a failing
+ * identity. You **must** handle this in your own code, as the ID3Global API does not provide any kind of boolean value
+ * for whether a given identity passed identity verification or not.
+ *
+ * An exception is thrown if the web service fails or cannot be contacted.
+ */
+$validIdentityBandText = 'PASS'; // See note above about how this may differ for you
+
+$identity = new \ID3Global\Identity\Identity();
+$identity
+    ->setPersonalDetails($personalDetails)
+    ->setAddresses($addressContainer)
+    ->setContactDetails($contactDetails)
+    ->setIdentityDocuments($documentContainer);
+
+$gateway = new \ID3Global\Gateway\GlobalAuthenticationGateway('username', 'password');
+$id3Service = new \ID3Global\Service\GlobalAuthenticationService($gateway);
+$result = $id3Service
+    ->setProfileId('Profile ID as provided by ID3global interface')
+    ->setProfileVersion(0)
+    ->setPilotSiteEnabled(true)
+    ->verifyIdentity($identity, 'Unique customer reference');
+
+if($result === $validIdentityBandText) {
+    // Identity is verified, continue processing
+}
+```

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,102 @@
+<?xml version="1.0"?>
+<ruleset name="id3global-service">
+    <description>PHP Code Sniffer ruleset for id3global-service module.</description>
+
+    <file>src/</file>
+    <file>tests/</file>
+
+    <!-- Include all PSR-12 coding standards -->
+    <rule ref="PSR12">
+        <!-- Exclude camelCaps method name rule, because we can't use @phpcsSuppress to suppress it on SOAP classes -->
+        <!-- where we have no choice but to use it because the method names need to match the SOAP endpoint names. -->
+        <exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps"/>
+    </rule>
+
+    <!-- Import all slevomat/coding-standard rules, then customise some of them below -->
+    <rule ref="vendor/slevomat/coding-standard/SlevomatCodingStandard/ruleset.xml">
+        <!-- Exclude forcing fully-qualified namespaces in docblocks and exceptions - we declare as use instead -->
+        <!-- Exclude forcing fully-qualified global functions and consts -->
+        <exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameInAnnotation"/>
+        <exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedExceptions.NonFullyQualifiedException"/>
+        <exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalFunctions.NonFullyQualified"/>
+        <exclude name="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalConstants.NonFullyQualified"/>
+
+        <!-- Allow the use of any namespace - can't make the namespace exclusion work for `ID3Global` namespace -->
+        <exclude name="SlevomatCodingStandard.Namespaces.UseOnlyWhitelistedNamespaces"/>
+
+        <!-- Allow use of superfluous Exception naming to match internal PHP exception classes -->
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming.SuperfluousSuffix"/>
+
+        <!-- Allow the use of `use` statements for simpler docblocks - phpcs doesn't notice that `use` statements -->
+        <!-- are actually used in docblocks -->
+        <exclude name="SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse"/>
+
+        <!-- Allow multi-line docblock even when there's only a single line description -->
+        <exclude name="SlevomatCodingStandard.Commenting.RequireOneLineDocComment.MultiLineDocComment"/>
+        <exclude name="SlevomatCodingStandard.Commenting.RequireOneLinePropertyDocComment.MultiLinePropertyComment"/>
+
+        <!-- Don't require a trailing comma in multi-line function calls -->
+        <exclude name="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall.MissingTrailingComma"/>
+
+        <!-- Don't force the usage of hard-to-understand ternary operators for 'simple' conditional blocks -->
+        <exclude name="SlevomatCodingStandard.ControlStructures.RequireTernaryOperator.TernaryOperatorNotUsed"/>
+
+        <!-- Allow 'useless' parentheses when instantiating new classes -->
+        <exclude name="SlevomatCodingStandard.ControlStructures.NewWithoutParentheses.UselessParentheses"/>
+
+        <!-- Ignore suggestions that make the code more convoluted -->
+        <exclude name="SlevomatCodingStandard.ControlStructures.EarlyExit.EarlyExitNotUsed"/>
+
+        <!-- Ignore deprecated sniffs -->
+        <exclude name="SlevomatCodingStandard.Files.FunctionLength.FunctionLength"/>
+        <exclude name="SlevomatCodingStandard.Functions.FunctionLength.FunctionLength"/>
+
+        <!-- Yoda conditionals aren't actually that good, especially when we enforce strict type checking anyway -->
+        <exclude name="SlevomatCodingStandard.ControlStructures.RequireYodaComparison.RequiredYodaComparison"/>
+
+        <!-- Don't require separation of integers with underscores e.g. 1974 is fine, we don't need to say 1_974 -->
+        <exclude name="SlevomatCodingStandard.Numbers.RequireNumericLiteralSeparator.RequiredNumericLiteralSeparator"/>
+
+        <!-- Don't require constructor property promotion as we support both PHP7.4 and PHP 8 but run phpcs on 8 -->
+        <exclude name="SlevomatCodingStandard.Classes.RequireConstructorPropertyPromotion.RequiredConstructorPropertyPromotion"/>
+    </rule>
+
+    <!-- Require no blank lines after the opening and closing braces {} defining a class -->
+    <rule ref="SlevomatCodingStandard.Classes.EmptyLinesAroundClassBraces">
+        <properties>
+            <property name="linesCountAfterOpeningBrace" value="0"/>
+            <property name="linesCountBeforeClosingBrace" value="0"/>
+        </properties>
+    </rule>
+
+    <!-- Match PSR-12 standard (not having any spaces around the strict type declaration -->
+    <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
+        <properties>
+            <property name="spacesCountAroundEqualsSign" value="0" />
+        </properties>
+    </rule>
+
+    <!-- Ensure PSR-4 autoloading is consistent by specifying our root namespace and directory structure -->
+    <rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName">
+        <properties>
+            <property name="rootNamespaces" type="array">
+                <element key="src" value="ID3Global"/>
+                <element key="tests" value="ID3Global\Tests"/>
+            </property>
+        </properties>
+    </rule>
+
+    <!-- Don't require us to define a 'mixed' return typehint as this isn't supported on PHP 7.4 -->
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
+        <properties>
+            <property name="enableMixedTypeHint" value="false"/>
+        </properties>
+    </rule>
+
+    <!-- Don't require use of ::class on objects as this is only supported in PHP8 and we support 7.4 as well -->
+    <rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference">
+        <properties>
+            <property name="enableOnObjects" value="false"/>
+        </properties>
+    </rule>
+</ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -36,7 +36,8 @@
         <exclude name="SlevomatCodingStandard.Commenting.RequireOneLinePropertyDocComment.MultiLinePropertyComment"/>
 
         <!-- Don't require a trailing comma in multi-line function calls -->
-        <exclude name="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall.MissingTrailingComma"/>
+        <exclude name="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall"/>
+        <exclude name="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration"/>
 
         <!-- Don't force the usage of hard-to-understand ternary operators for 'simple' conditional blocks -->
         <exclude name="SlevomatCodingStandard.ControlStructures.RequireTernaryOperator.TernaryOperatorNotUsed"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="vendor/autoload.php" convertErrorsToExceptions="true">
-    <coverage processUncoveredFiles="true">
+    <coverage processUncoveredFiles="true" includeUncoveredFiles="true" pathCoverage="true">
         <include>
-            <directory suffix=".php">./src</directory>
+            <directory suffix=".php">src</directory>
         </include>
+
+        <report>
+            <clover outputFile=".artifacts/phpunit-codecoverage.xml"/>
+        </report>
     </coverage>
+
     <testsuites>
         <testsuite name="ID3Global Service tests">
             <directory suffix="Test.php">./tests/</directory>

--- a/src/Exceptions/IdentityVerificationFailureException.php
+++ b/src/Exceptions/IdentityVerificationFailureException.php
@@ -1,18 +1,43 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ID3Global\Exceptions;
 
 use Exception;
+use ID3Global\Service\GlobalAuthenticationService;
 use stdClass;
 
+/**
+ * Exception generated when the identity verification response from the ID3global API fails to validate our simple
+ * tests.
+ *
+ * CAUTION: It's important to note that the ID3global response that we return within the exception message *will*
+ * contain PII (personally identifiable information) if verbose logging is enabled. For this reason, by default verbose
+ * logging is disabled however you can still access the response object for your own processing during a `catch` block.
+ *
+ * @see GlobalAuthenticationService::verifyIdentity()
+ */
 class IdentityVerificationFailureException extends Exception
 {
     private stdClass $response;
 
-    public function __construct($response)
+    /**
+     * @param stdClass $response The full response object returned by ID3global. Very useful for later debugging.
+     */
+    public function __construct(stdClass $response, bool $verbose = false)
     {
+        if ($verbose) {
+            $message = sprintf(
+                'Invalid Response returned by ID3global API. Serialized response: %s',
+                serialize($response)
+            );
+        } else {
+            $message = 'Invalid Response returned by ID3global API. Verbose logging of API response not enabled.';
+        }
+
         $this->response = $response;
-        $message = sprintf('Invalid Response returned by ID3global API. Serialized response: %s', serialize($response));
+
         parent::__construct($message);
     }
 

--- a/src/Gateway/GlobalAuthenticationGateway.php
+++ b/src/Gateway/GlobalAuthenticationGateway.php
@@ -10,14 +10,18 @@ use stdClass;
 
 class GlobalAuthenticationGateway extends ID3GlobalBaseGateway
 {
-    public function AuthenticateSP(string $pId, int $pVer, ?string $customerReference, Identity $identity): stdClass
-    {
+    public function AuthenticateSP(
+        string $profileId,
+        int $profileVersion,
+        ?string $customerReference,
+        Identity $identity
+    ): stdClass {
         $request = new AuthenticateSPRequest();
         $request->setCustomerReference($customerReference);
 
         $profile = new stdClass();
-        $profile->Version = $pVer;
-        $profile->ID = $pId;
+        $profile->ID = $profileId;
+        $profile->Version = $profileVersion;
         $request->setProfileIDVersion($profile);
 
         $request->addFieldsFromIdentity($identity);

--- a/src/Gateway/GlobalAuthenticationGateway.php
+++ b/src/Gateway/GlobalAuthenticationGateway.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ID3Global\Gateway;
 
 use ID3Global\Gateway\Request\AuthenticateSPRequest;
@@ -8,14 +10,14 @@ use stdClass;
 
 class GlobalAuthenticationGateway extends ID3GlobalBaseGateway
 {
-    public function AuthenticateSP(string $profileID, int $profileVersion, ?string $customerReference, Identity $identity)
+    public function AuthenticateSP(string $pId, int $pVer, ?string $customerReference, Identity $identity): stdClass
     {
         $request = new AuthenticateSPRequest();
         $request->setCustomerReference($customerReference);
 
         $profile = new stdClass();
-        $profile->Version = $profileVersion;
-        $profile->ID = $profileID;
+        $profile->Version = $pVer;
+        $profile->ID = $pId;
         $request->setProfileIDVersion($profile);
 
         $request->addFieldsFromIdentity($identity);

--- a/src/Gateway/ID3GlobalBaseGateway.php
+++ b/src/Gateway/ID3GlobalBaseGateway.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ID3Global\Gateway;
 
 use ID3Global\Gateway\SoapClient\ID3GlobalSoapClient;
@@ -7,7 +9,7 @@ use ID3Global\Gateway\SoapClient\ID3GlobalSoapClient;
 abstract class ID3GlobalBaseGateway
 {
     /**
-     * @var ID3GlobalSoapClient
+     * @var ID3GlobalSoapClient The custom SoapClient sub-class used to ensure the correct wsse:Security headers exist.
      */
     private ID3GlobalSoapClient $client;
 
@@ -15,9 +17,17 @@ abstract class ID3GlobalBaseGateway
 
     private string $liveSiteWsdl = 'https://id3global.com/ID3gWS/ID3global.svc?wsdl';
 
-    public function __construct($username, $password, $soapClientOptions = [], $usePilotSite = false)
+    /**
+     * @param string $username The username for the ID3global API.
+     * @param string $password The password for the ID3global API.
+     * @param array $options See https://www.php.net/manual/en/soapclient.construct.php for options.
+     * @param bool $usePilotSite true to use the ID3Global API pilot (test) environment, false to use production env.
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification
+     * @throws \SoapFault
+     */
+    public function __construct(string $username, string $password, array $options = [], bool $usePilotSite = false)
     {
-        if ((bool) $usePilotSite) {
+        if ($usePilotSite) {
             $wsdl = $this->pilotSiteWsdl;
         } else {
             $wsdl = $this->liveSiteWsdl;
@@ -25,12 +35,13 @@ abstract class ID3GlobalBaseGateway
 
         $defaultOptions = [
             'soap_version' => SOAP_1_1,
-            'exceptions'   => true,
+            'exceptions' => true,
+
             // We always enable trace so that requests and responses can be logged if required by calling applications
             'trace' => true,
         ];
 
-        $soapClientOptions = array_merge($defaultOptions, $soapClientOptions);
+        $soapClientOptions = array_merge($defaultOptions, $options);
 
         $this->setClient(new ID3GlobalSoapClient($wsdl, $username, $password, $soapClientOptions));
     }

--- a/src/Gateway/Request/AuthenticateSPRequest.php
+++ b/src/Gateway/Request/AuthenticateSPRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ID3Global\Gateway\Request;
 
 use ID3Global\Identity\Address\Address;
@@ -14,21 +16,21 @@ use stdClass;
 class AuthenticateSPRequest
 {
     /**
-     * @var ?string
+     * @var ?string The customer reference as provided during the call to GlobalAuthenticationService->verifyIdentity().
      */
     private ?string $CustomerReference;
 
     /**
-     * @var stdClass
+     * @var stdClass The Profile ID and Version in a single stdClass object as required by the ID3global API.
      */
     private stdClass $ProfileIDVersion;
 
     /**
-     * @var stdClass
+     * @var stdClass All other input data for an Identity to be provided to the ID3global API.
      */
     private stdClass $InputData;
 
-    public function addFieldsFromIdentity(Identity $identity)
+    public function addFieldsFromIdentity(Identity $identity): void
     {
         $this->InputData = new stdClass();
 
@@ -38,7 +40,50 @@ class AuthenticateSPRequest
         $this->addContactDetails($identity);
     }
 
-    private function addPersonalDetails(Identity $identity)
+    /**
+     * @return string The customer reference as provided to GlobalAuthenticationService->verifyIdentity().
+     */
+    public function getCustomerReference(): string
+    {
+        return $this->CustomerReference;
+    }
+
+    /**
+     * @param ?string $CustomerReference Customer reference as provided to GlobalAuthenticationService->verifyIdentity()
+     * @return AuthenticateSPRequest
+     */
+    public function setCustomerReference(?string $CustomerReference): self
+    {
+        $this->CustomerReference = $CustomerReference;
+
+        return $this;
+    }
+
+    /**
+     * @return stdClass A stdClass that includes ->Version and ->ID values, correlating to Profile Version and ID.
+     */
+    public function getProfileIDVersion(): stdClass
+    {
+        return $this->ProfileIDVersion;
+    }
+
+    /**
+     * @param stdClass $ProfileIDVersion A complete stdClass including both ->Version and ->ID values.
+     * @return AuthenticateSPRequest
+     */
+    public function setProfileIDVersion(stdClass $ProfileIDVersion): self
+    {
+        $this->ProfileIDVersion = $ProfileIDVersion;
+
+        return $this;
+    }
+
+    public function getInputData(): stdClass
+    {
+        return $this->InputData;
+    }
+
+    private function addPersonalDetails(Identity $identity): void
     {
         $this->InputData->Personal = new stdClass();
         $personalDetails = $identity->getPersonalDetails();
@@ -48,7 +93,7 @@ class AuthenticateSPRequest
         }
     }
 
-    private function addAddresses(Identity $identity)
+    private function addAddresses(Identity $identity): void
     {
         $this->InputData->Addresses = new stdClass();
         $addresses = $identity->getAddresses();
@@ -62,7 +107,7 @@ class AuthenticateSPRequest
         }
     }
 
-    private function addIdentityDocuments(Identity $identity)
+    private function addIdentityDocuments(Identity $identity): void
     {
         $this->InputData->IdentityDocuments = new stdClass();
         $documents = $identity->getIdentityDocuments();
@@ -85,7 +130,7 @@ class AuthenticateSPRequest
         }
     }
 
-    private function addContactDetails(Identity $identity)
+    private function addContactDetails(Identity $identity): void
     {
         $this->InputData->ContactDetails = new stdClass();
         $contactDetails = $identity->getContactDetails();
@@ -94,64 +139,22 @@ class AuthenticateSPRequest
             $this->InputData->ContactDetails->Email = $contactDetails->getEmail();
 
             if ($contactDetails->getLandTelephone() instanceof ContactDetails\PhoneNumber) {
+                $number = $contactDetails->getLandTelephone()->getNumber();
                 $this->InputData->ContactDetails->LandTelephone = new stdClass();
-                $this->InputData->ContactDetails->LandTelephone->Number = $contactDetails->getLandTelephone()->getNumber();
+                $this->InputData->ContactDetails->LandTelephone->Number = $number;
             }
 
             if ($contactDetails->getMobileTelephone() instanceof ContactDetails\PhoneNumber) {
+                $number = $contactDetails->getMobileTelephone()->getNumber();
                 $this->InputData->ContactDetails->MobileTelephone = new stdClass();
-                $this->InputData->ContactDetails->MobileTelephone->Number = $contactDetails->getMobileTelephone()->getNumber();
+                $this->InputData->ContactDetails->MobileTelephone->Number = $number;
             }
 
             if ($contactDetails->getWorkTelephone() instanceof ContactDetails\PhoneNumber) {
+                $number = $contactDetails->getWorkTelephone()->getNumber();
                 $this->InputData->ContactDetails->WorkTelephone = new stdClass();
-                $this->InputData->ContactDetails->WorkTelephone->Number = $contactDetails->getWorkTelephone()->getNumber();
+                $this->InputData->ContactDetails->WorkTelephone->Number = $number;
             }
         }
-    }
-
-    /**
-     * @return ?string
-     */
-    public function getCustomerReference(): ?string
-    {
-        return $this->CustomerReference;
-    }
-
-    /**
-     * @param ?string $CustomerReference
-     *
-     * @return AuthenticateSPRequest
-     */
-    public function setCustomerReference(?string $CustomerReference): AuthenticateSPRequest
-    {
-        $this->CustomerReference = $CustomerReference;
-
-        return $this;
-    }
-
-    /**
-     * @return stdClass
-     */
-    public function getProfileIDVersion(): stdClass
-    {
-        return $this->ProfileIDVersion;
-    }
-
-    /**
-     * @param stdClass $ProfileIDVersion
-     *
-     * @return AuthenticateSPRequest
-     */
-    public function setProfileIDVersion(stdClass $ProfileIDVersion): AuthenticateSPRequest
-    {
-        $this->ProfileIDVersion = $ProfileIDVersion;
-
-        return $this;
-    }
-
-    public function getInputData(): stdClass
-    {
-        return $this->InputData;
     }
 }

--- a/src/Gateway/SoapClient/ID3GlobalSoapClient.php
+++ b/src/Gateway/SoapClient/ID3GlobalSoapClient.php
@@ -1,16 +1,29 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ID3Global\Gateway\SoapClient;
 
-use ID3Global\Gateway\Request\AuthenticateSPRequest;
 use SoapClient;
 
 /**
- * @method AuthenticateSP(AuthenticateSPRequest $request)
+ * This class is a thin wrapper around PHP's built in SoapClient and the ext-soap extension. This is only required to
+ * forcefully configure SOAP headers to include the custom ID3WsseAuthHeader as the built-in WSSE configuration that
+ * SoapClient includes doesn't work with the ID3global API.
+ *
+ * @method AuthenticateSP(\ID3Global\Gateway\Request\AuthenticateSPRequest $request)
  */
 class ID3GlobalSoapClient extends SoapClient
 {
-    public function __construct($wsdl, $username, $password, $options = [])
+    /**
+     * @param string $wsdl The path to the WSDL file (we always use WSDL mode). This differs for the pilot vs. live env.
+     * @param string $username The ID3global username to be used.
+     * @param string $password The ID3global password to be used.
+     * @param array $options See https://www.php.net/manual/en/soapclient.construct.php for options.
+     * @throws \SoapFault
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification
+     */
+    public function __construct(string $wsdl, string $username, string $password, array $options = [])
     {
         parent::__construct($wsdl, $options);
 

--- a/src/Gateway/SoapClient/ID3WsseAuthHeader.php
+++ b/src/Gateway/SoapClient/ID3WsseAuthHeader.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ID3Global\Gateway\SoapClient;
 
 use SoapHeader;
@@ -8,24 +10,46 @@ use stdClass;
 
 class ID3WsseAuthHeader extends SoapHeader
 {
-    private $wsseNamespace = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd';
+    /**
+     * @var string The WSSE XML namespace to be added to each SoapVar.
+     */
+    private string $wsseNamespace = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd';
 
-    public function __construct($username, $password, $ns = null)
+    /**
+     * @param string $username The username for the ID3global API.
+     * @param string $password The password for the ID3global API.
+     * @param ?string $ns The XSSE namespace (if not the default)
+     */
+    public function __construct(string $username, string $password, ?string $ns = '')
     {
         if ($ns) {
             $this->wsseNamespace = $ns;
         }
 
         $auth = new stdClass();
-        $auth->Username = new SoapVar($username, XSD_STRING, null, $this->wsseNamespace, null, $this->wsseNamespace);
-        $auth->Password = new SoapVar($password, XSD_STRING, null, $this->wsseNamespace, null, $this->wsseNamespace);
+        $auth->Username = new SoapVar($username, XSD_STRING, '', $this->wsseNamespace, '', $this->wsseNamespace);
+        $auth->Password = new SoapVar($password, XSD_STRING, '', $this->wsseNamespace, '', $this->wsseNamespace);
 
         $usernameToken = new stdClass();
-        $usernameToken->UsernameToken = new SoapVar($auth, SOAP_ENC_OBJECT, null, $this->wsseNamespace, 'UsernameToken', $this->wsseNamespace);
+        $usernameToken->UsernameToken = new SoapVar(
+            $auth,
+            SOAP_ENC_OBJECT,
+            '',
+            $this->wsseNamespace,
+            'UsernameToken',
+            $this->wsseNamespace
+        );
 
-        $token = new SoapVar($usernameToken, SOAP_ENC_OBJECT, null, $this->wsseNamespace, 'UsernameToken', $this->wsseNamespace);
+        $token = new SoapVar(
+            $usernameToken,
+            SOAP_ENC_OBJECT,
+            '',
+            $this->wsseNamespace,
+            'UsernameToken',
+            $this->wsseNamespace
+        );
 
-        $security = new SoapVar($token, SOAP_ENC_OBJECT, null, $this->wsseNamespace, 'Security', $this->wsseNamespace);
+        $security = new SoapVar($token, SOAP_ENC_OBJECT, '', $this->wsseNamespace, 'Security', $this->wsseNamespace);
 
         parent::__construct($this->wsseNamespace, 'Security', $security, true);
     }

--- a/src/Identity/Address/Address.php
+++ b/src/Identity/Address/Address.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ID3Global\Identity\Address;
 
 interface Address

--- a/src/Identity/Address/AddressContainer.php
+++ b/src/Identity/Address/AddressContainer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ID3Global\Identity\Address;
 
 use ID3Global\Identity\ID3IdentityObject;

--- a/src/Identity/Address/FixedFormatAddress.php
+++ b/src/Identity/Address/FixedFormatAddress.php
@@ -1,84 +1,42 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ID3Global\Identity\Address;
 
 use ID3Global\Identity\ID3IdentityObject;
 
 class FixedFormatAddress extends ID3IdentityObject implements Address
 {
-    /**
-     * @var string|null
-     */
     private ?string $Country = null;
 
-    /**
-     * @var string|null
-     */
     private ?string $Street = null;
 
-    /**
-     * @var string|null
-     */
     private ?string $SubStreet = null;
 
-    /**
-     * @var string|null
-     */
     private ?string $City = null;
 
-    /**
-     * @var string|null
-     */
     private ?string $SubCity = null;
 
-    /**
-     * @var string|null
-     */
     private ?string $StateDistrict = null;
 
-    /**
-     * @var string|null
-     */
     private ?string $Region = null;
 
-    /**
-     * @var string|null
-     */
     private ?string $Principality = null;
 
-    /**
-     * @var string|null
-     */
     private ?string $ZipPostcode = null;
 
-    /**
-     * @var string|null
-     */
     private ?string $Building = null;
 
-    /**
-     * @var string|null
-     */
     private ?string $SubBuilding = null;
 
-    /**
-     * @var string|null
-     */
     private ?string $Premise = null;
 
-    /**
-     * @return string|null
-     */
     public function getCountry(): ?string
     {
         return $this->Country;
     }
 
-    /**
-     * @param string|null $country
-     *
-     * @return FixedFormatAddress
-     */
     public function setCountry(?string $country): FixedFormatAddress
     {
         $this->Country = $country;
@@ -86,19 +44,11 @@ class FixedFormatAddress extends ID3IdentityObject implements Address
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getStreet(): ?string
     {
         return $this->Street;
     }
 
-    /**
-     * @param string|null $street
-     *
-     * @return FixedFormatAddress
-     */
     public function setStreet(?string $street): FixedFormatAddress
     {
         $this->Street = $street;
@@ -106,19 +56,11 @@ class FixedFormatAddress extends ID3IdentityObject implements Address
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getSubStreet(): ?string
     {
         return $this->SubStreet;
     }
 
-    /**
-     * @param string|null $subStreet
-     *
-     * @return FixedFormatAddress
-     */
     public function setSubStreet(?string $subStreet): FixedFormatAddress
     {
         $this->SubStreet = $subStreet;
@@ -126,19 +68,11 @@ class FixedFormatAddress extends ID3IdentityObject implements Address
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getCity(): ?string
     {
         return $this->City;
     }
 
-    /**
-     * @param string|null $city
-     *
-     * @return FixedFormatAddress
-     */
     public function setCity(?string $city): FixedFormatAddress
     {
         $this->City = $city;
@@ -146,19 +80,11 @@ class FixedFormatAddress extends ID3IdentityObject implements Address
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getSubCity(): ?string
     {
         return $this->SubCity;
     }
 
-    /**
-     * @param string|null $subCity
-     *
-     * @return FixedFormatAddress
-     */
     public function setSubCity(?string $subCity): FixedFormatAddress
     {
         $this->SubCity = $subCity;
@@ -166,19 +92,11 @@ class FixedFormatAddress extends ID3IdentityObject implements Address
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getStateDistrict(): ?string
     {
         return $this->StateDistrict;
     }
 
-    /**
-     * @param string|null $stateDistrict
-     *
-     * @return FixedFormatAddress
-     */
     public function setStateDistrict(?string $stateDistrict): FixedFormatAddress
     {
         $this->StateDistrict = $stateDistrict;
@@ -186,19 +104,11 @@ class FixedFormatAddress extends ID3IdentityObject implements Address
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getRegion(): ?string
     {
         return $this->Region;
     }
 
-    /**
-     * @param string|null $region
-     *
-     * @return FixedFormatAddress
-     */
     public function setRegion(?string $region): FixedFormatAddress
     {
         $this->Region = $region;
@@ -206,19 +116,11 @@ class FixedFormatAddress extends ID3IdentityObject implements Address
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getPrincipality(): ?string
     {
         return $this->Principality;
     }
 
-    /**
-     * @param string|null $principality
-     *
-     * @return FixedFormatAddress
-     */
     public function setPrincipality(?string $principality): FixedFormatAddress
     {
         $this->Principality = $principality;
@@ -226,19 +128,11 @@ class FixedFormatAddress extends ID3IdentityObject implements Address
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getZipPostcode(): ?string
     {
         return $this->ZipPostcode;
     }
 
-    /**
-     * @param string|null $zipPostcode
-     *
-     * @return FixedFormatAddress
-     */
     public function setZipPostcode(?string $zipPostcode): FixedFormatAddress
     {
         $this->ZipPostcode = $zipPostcode;
@@ -246,19 +140,11 @@ class FixedFormatAddress extends ID3IdentityObject implements Address
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getBuilding(): ?string
     {
         return $this->Building;
     }
 
-    /**
-     * @param string|null $building
-     *
-     * @return FixedFormatAddress
-     */
     public function setBuilding(?string $building): FixedFormatAddress
     {
         $this->Building = $building;
@@ -266,19 +152,11 @@ class FixedFormatAddress extends ID3IdentityObject implements Address
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getSubBuilding(): ?string
     {
         return $this->SubBuilding;
     }
 
-    /**
-     * @param string|null $subBuilding
-     *
-     * @return FixedFormatAddress
-     */
     public function setSubBuilding(?string $subBuilding): FixedFormatAddress
     {
         $this->SubBuilding = $subBuilding;
@@ -286,19 +164,11 @@ class FixedFormatAddress extends ID3IdentityObject implements Address
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getPremise(): ?string
     {
         return $this->Premise;
     }
 
-    /**
-     * @param string|null $premise
-     *
-     * @return FixedFormatAddress
-     */
     public function setPremise(?string $premise): FixedFormatAddress
     {
         $this->Premise = $premise;

--- a/src/Identity/Address/FreeFormatAddress.php
+++ b/src/Identity/Address/FreeFormatAddress.php
@@ -1,74 +1,38 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ID3Global\Identity\Address;
 
 use ID3Global\Identity\ID3IdentityObject;
 
 class FreeFormatAddress extends ID3IdentityObject implements Address
 {
-    /**
-     * @var string|null
-     */
     private ?string $Country = null;
 
-    /**
-     * @var string|null
-     */
     private ?string $ZipPostcode = null;
 
-    /**
-     * @var string|null
-     */
     private ?string $AddressLine1 = null;
 
-    /**
-     * @var string|null
-     */
     private ?string $AddressLine2 = null;
 
-    /**
-     * @var string|null
-     */
     private ?string $AddressLine3 = null;
 
-    /**
-     * @var string|null
-     */
     private ?string $AddressLine4 = null;
 
-    /**
-     * @var string|null
-     */
     private ?string $AddressLine5 = null;
 
-    /**
-     * @var string|null
-     */
     private ?string $AddressLine6 = null;
 
-    /**
-     * @var string|null
-     */
     private ?string $AddressLine7 = null;
 
-    /**
-     * @var string|null
-     */
     private ?string $AddressLine8 = null;
 
-    /**
-     * @return string|null
-     */
     public function getCountry(): ?string
     {
         return $this->Country;
     }
 
-    /**
-     * @param string|null $Country
-     *
-     * @return FreeFormatAddress
-     */
     public function setCountry(?string $Country): FreeFormatAddress
     {
         $this->Country = $Country;
@@ -76,19 +40,11 @@ class FreeFormatAddress extends ID3IdentityObject implements Address
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getPostCode(): ?string
     {
         return $this->ZipPostcode;
     }
 
-    /**
-     * @param string|null $PostCode
-     *
-     * @return FreeFormatAddress
-     */
     public function setPostCode(?string $PostCode): FreeFormatAddress
     {
         $this->ZipPostcode = $PostCode;
@@ -96,9 +52,6 @@ class FreeFormatAddress extends ID3IdentityObject implements Address
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getAddressLine1(): ?string
     {
         return $this->AddressLine1;
@@ -107,8 +60,6 @@ class FreeFormatAddress extends ID3IdentityObject implements Address
     /**
      * @param string|null $AddressLine1
      *?
-     *
-     * @return FreeFormatAddress
      */
     public function setAddressLine1(?string $AddressLine1): FreeFormatAddress
     {
@@ -117,19 +68,11 @@ class FreeFormatAddress extends ID3IdentityObject implements Address
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getAddressLine2(): ?string
     {
         return $this->AddressLine2;
     }
 
-    /**
-     * @param string|null $AddressLine2
-     *
-     * @return FreeFormatAddress
-     */
     public function setAddressLine2(?string $AddressLine2): FreeFormatAddress
     {
         $this->AddressLine2 = $AddressLine2;
@@ -137,19 +80,11 @@ class FreeFormatAddress extends ID3IdentityObject implements Address
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getAddressLine3(): ?string
     {
         return $this->AddressLine3;
     }
 
-    /**
-     * @param string|null $AddressLine3
-     *
-     * @return FreeFormatAddress
-     */
     public function setAddressLine3(?string $AddressLine3): FreeFormatAddress
     {
         $this->AddressLine3 = $AddressLine3;
@@ -157,19 +92,11 @@ class FreeFormatAddress extends ID3IdentityObject implements Address
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getAddressLine4(): ?string
     {
         return $this->AddressLine4;
     }
 
-    /**
-     * @param string|null $AddressLine4
-     *
-     * @return FreeFormatAddress
-     */
     public function setAddressLine4(?string $AddressLine4): FreeFormatAddress
     {
         $this->AddressLine4 = $AddressLine4;
@@ -177,19 +104,11 @@ class FreeFormatAddress extends ID3IdentityObject implements Address
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getAddressLine5(): ?string
     {
         return $this->AddressLine5;
     }
 
-    /**
-     * @param string|null $AddressLine5
-     *
-     * @return FreeFormatAddress
-     */
     public function setAddressLine5(?string $AddressLine5): FreeFormatAddress
     {
         $this->AddressLine5 = $AddressLine5;
@@ -197,19 +116,11 @@ class FreeFormatAddress extends ID3IdentityObject implements Address
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getAddressLine6(): ?string
     {
         return $this->AddressLine6;
     }
 
-    /**
-     * @param string|null $AddressLine6
-     *
-     * @return FreeFormatAddress
-     */
     public function setAddressLine6(?string $AddressLine6): FreeFormatAddress
     {
         $this->AddressLine6 = $AddressLine6;
@@ -217,19 +128,11 @@ class FreeFormatAddress extends ID3IdentityObject implements Address
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getAddressLine7(): ?string
     {
         return $this->AddressLine7;
     }
 
-    /**
-     * @param string|null $AddressLine7
-     *
-     * @return FreeFormatAddress
-     */
     public function setAddressLine7(?string $AddressLine7): FreeFormatAddress
     {
         $this->AddressLine7 = $AddressLine7;
@@ -237,19 +140,11 @@ class FreeFormatAddress extends ID3IdentityObject implements Address
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getAddressLine8(): ?string
     {
         return $this->AddressLine8;
     }
 
-    /**
-     * @param string|null $AddressLine8
-     *
-     * @return FreeFormatAddress
-     */
     public function setAddressLine8(?string $AddressLine8): FreeFormatAddress
     {
         $this->AddressLine8 = $AddressLine8;

--- a/src/Identity/ContactDetails.php
+++ b/src/Identity/ContactDetails.php
@@ -1,44 +1,26 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ID3Global\Identity;
 
 use ID3Global\Identity\ContactDetails\PhoneNumber;
 
 class ContactDetails
 {
-    /**
-     * @var PhoneNumber|null
-     */
     private ?PhoneNumber $LandTelephone = null;
 
-    /**
-     * @var PhoneNumber|null
-     */
     private ?PhoneNumber $MobileTelephone = null;
 
-    /**
-     * @var PhoneNumber|null
-     */
     private ?PhoneNumber $WorkTelephone = null;
 
-    /**
-     * @var string|null
-     */
     private ?string $Email = null;
 
-    /**
-     * @return PhoneNumber|null
-     */
     public function getLandTelephone(): ?PhoneNumber
     {
         return $this->LandTelephone;
     }
 
-    /**
-     * @param PhoneNumber|null $LandTelephone
-     *
-     * @return ContactDetails
-     */
     public function setLandTelephone(?PhoneNumber $LandTelephone): ContactDetails
     {
         $this->LandTelephone = $LandTelephone;
@@ -46,19 +28,11 @@ class ContactDetails
         return $this;
     }
 
-    /**
-     * @return PhoneNumber|null
-     */
     public function getMobileTelephone(): ?PhoneNumber
     {
         return $this->MobileTelephone;
     }
 
-    /**
-     * @param PhoneNumber|null $MobileTelephone
-     *
-     * @return ContactDetails
-     */
     public function setMobileTelephone(?PhoneNumber $MobileTelephone): ContactDetails
     {
         $this->MobileTelephone = $MobileTelephone;
@@ -66,19 +40,11 @@ class ContactDetails
         return $this;
     }
 
-    /**
-     * @return PhoneNumber|null
-     */
     public function getWorkTelephone(): ?PhoneNumber
     {
         return $this->WorkTelephone;
     }
 
-    /**
-     * @param PhoneNumber|null $WorkTelephone
-     *
-     * @return ContactDetails
-     */
     public function setWorkTelephone(?PhoneNumber $WorkTelephone): ContactDetails
     {
         $this->WorkTelephone = $WorkTelephone;
@@ -91,11 +57,6 @@ class ContactDetails
         return $this->Email;
     }
 
-    /**
-     * @param string|null $Email
-     *
-     * @return ContactDetails
-     */
     public function setEmail(?string $Email): ContactDetails
     {
         $this->Email = $Email;

--- a/src/Identity/ContactDetails/PhoneNumber.php
+++ b/src/Identity/ContactDetails/PhoneNumber.php
@@ -1,19 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ID3Global\Identity\ContactDetails;
 
 class PhoneNumber
 {
-    /**
-     * @var ?string
-     */
     private ?string $Number;
 
-    /**
-     * @param ?string $Number
-     *
-     * @return PhoneNumber
-     */
     public function setNumber(?string $Number): PhoneNumber
     {
         $this->Number = $Number;
@@ -21,9 +15,6 @@ class PhoneNumber
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getNumber(): ?string
     {
         return $this->Number;

--- a/src/Identity/Documents/DocumentContainer.php
+++ b/src/Identity/Documents/DocumentContainer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ID3Global\Identity\Documents;
 
 use ID3Global\Identity\ID3IdentityObject;
@@ -10,64 +12,55 @@ use stdClass;
 class DocumentContainer extends ID3IdentityObject
 {
     /**
-     * @var InternationalPassport|null
+     * @var InternationalPassport|null A passport identity document that will be sent to the ID3Global API. Only one can
+     * be sent.
      */
     private ?InternationalPassport $InternationalPassport = null;
 
     /**
-     * @var stdClass|null Identity documents relevant to New Zealand
+     * @var stdClass|null Identity documents relevant specifically to New Zealand.
      */
     private ?stdClass $NewZealand = null;
 
     /**
-     * @var array Used by self::addIdentityDocument() to ensure the country name is valid
+     * @var array<string> Used by self::addIdentityDocument() to ensure the country name is valid. Each array item is
+     * the country name, per ID3global documentation for the `GlobalIdentityDocuments` type, which can be viewed in
+     * their documentation here: https://bit.ly/2WWVHfW+
      */
     private array $validCountries = [
         'NewZealand',
     ];
 
-    /**
-     * @return InternationalPassport|null
-     */
     public function getInternationalPassport(): ?InternationalPassport
     {
         return $this->InternationalPassport;
     }
 
-    /**
-     * @param InternationalPassport $InternationalPassport
-     *
-     * @return DocumentContainer
-     */
-    public function setInternationalPassport(InternationalPassport $InternationalPassport): DocumentContainer
+    public function setInternationalPassport(InternationalPassport $InternationalPassport): self
     {
         $this->InternationalPassport = $InternationalPassport;
 
         return $this;
     }
 
-    /**
-     * @return stdClass|null
-     */
     public function getNewZealandDocuments(): ?stdClass
     {
         return $this->NewZealand;
     }
 
     /**
-     * @param ID3IdentityObject $document
-     * @param string            $country  The country to assign this document to (e.g. 'New Zealand')
-     *
+     * @param ID3IdentityObject $document An identity document to be assigned to a country-specific container
+     * @param string $country The country to assign this document to (e.g. 'New Zealand')
      * @return DocumentContainer
      */
-    public function addIdentityDocument(ID3IdentityObject $document, string $country): DocumentContainer
+    public function addIdentityDocument(ID3IdentityObject $document, string $country): self
     {
-        //
+        // Remove any characters that aren't A-Z or a-z (e.g. "New Zealand" -> "NewZealand")
         $varName = preg_replace('/[^A-Za-z]*/', '', $country);
         $r = new ReflectionClass($document);
         $docType = $r->getShortName();
 
-        if (in_array($varName, $this->validCountries)) {
+        if (in_array($varName, $this->validCountries, true)) {
             if (is_null($this->$varName)) {
                 $this->$varName = new stdClass();
             }
@@ -80,6 +73,9 @@ class DocumentContainer extends ID3IdentityObject
         return $this;
     }
 
+    /**
+     * @return array<string> The list of all valid countries
+     */
     public function getValidCountries(): array
     {
         return $this->validCountries;

--- a/src/Identity/Documents/InternationalPassport.php
+++ b/src/Identity/Documents/InternationalPassport.php
@@ -114,7 +114,7 @@ class InternationalPassport extends ID3IdentityObject
         return $this;
     }
 
-    public function setExpiryDate(?DateTime $expiryDate): InternationalPassport
+    public function setExpiryDate(DateTime $expiryDate): InternationalPassport
     {
         $this->setExpiryDay((int)$expiryDate->format('d'));
         $this->setExpiryMonth((int)$expiryDate->format('m'));
@@ -159,7 +159,7 @@ class InternationalPassport extends ID3IdentityObject
         return $this;
     }
 
-    public function setIssueDate(?DateTime $issueDate): InternationalPassport
+    public function setIssueDate(DateTime $issueDate): InternationalPassport
     {
         $this->setIssueDay((int)$issueDate->format('d'));
         $this->setIssueMonth((int)$issueDate->format('m'));

--- a/src/Identity/Documents/InternationalPassport.php
+++ b/src/Identity/Documents/InternationalPassport.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ID3Global\Identity\Documents;
 
 use DateTime;
@@ -8,63 +10,55 @@ use ID3Global\Identity\ID3IdentityObject;
 class InternationalPassport extends ID3IdentityObject
 {
     /**
-     * @var string|null The full unique passport identifier (varies by country)
+     * @var string|null The full unique passport identifier (varies by country).
      */
     private ?string $Number = null;
 
     /**
-     * @var string|null The short unique passport identifier (varies by country)
+     * @var string|null The short unique passport identifier (varies by country).
      */
     private ?string $ShortPassportNumber = null;
 
     /**
-     * @var int|null
+     * @var int|null The day (e.g. 1, 15, 31) that the passport expires.
      */
     private ?int $ExpiryDay = null;
 
     /**
-     * @var int|null
+     * @var int|null The month (e.g. 1, 5, 12) that the passport expires.
      */
     private ?int $ExpiryMonth = null;
 
     /**
-     * @var int|null
+     * @var int|null The year (e.g. 1997) that the passport expires.
      */
     private ?int $ExpiryYear = null;
 
     /**
-     * @var int|null
+     * @var int|null The day (e.g. 1, 15, 31) that the passport was issued.
      */
     private ?int $IssueDay = null;
 
     /**
-     * @var int|null
+     * @var int|null The month (e.g. 1, 5, 12) that the passport was issued.
      */
     private ?int $IssueMonth = null;
 
     /**
-     * @var int|null
+     * @var int|null The year (e.g. 1997) that the passport was issued.
      */
     private ?int $IssueYear = null;
 
     /**
-     * @var string|null The full country name (e.g. "New Zealand", not "NZ") that this passport was issued by
+     * @var string|null The full country name (e.g. "New Zealand", not "NZ") that this passport was issued by.
      */
     private ?string $CountryOfOrigin = null;
 
-    /**
-     * @return string|null
-     */
     public function getNumber(): ?string
     {
         return $this->Number;
     }
 
-    /**
-     * @param string|null $Number
-     *
-     * @return InternationalPassport
-     */
     public function setNumber(?string $Number): InternationalPassport
     {
         $this->Number = $Number;
@@ -72,19 +66,11 @@ class InternationalPassport extends ID3IdentityObject
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getShortPassportNumber(): ?string
     {
         return $this->ShortPassportNumber;
     }
 
-    /**
-     * @param string|null $ShortPassportNumber
-     *
-     * @return InternationalPassport
-     */
     public function setShortPassportNumber(?string $ShortPassportNumber): InternationalPassport
     {
         $this->ShortPassportNumber = $ShortPassportNumber;
@@ -92,19 +78,11 @@ class InternationalPassport extends ID3IdentityObject
         return $this;
     }
 
-    /**
-     * @return int|null
-     */
     public function getExpiryDay(): ?int
     {
         return $this->ExpiryDay;
     }
 
-    /**
-     * @param int|null $ExpiryDay
-     *
-     * @return InternationalPassport
-     */
     public function setExpiryDay(?int $ExpiryDay): InternationalPassport
     {
         $this->ExpiryDay = $ExpiryDay;
@@ -112,19 +90,11 @@ class InternationalPassport extends ID3IdentityObject
         return $this;
     }
 
-    /**
-     * @return int|null
-     */
     public function getExpiryMonth(): ?int
     {
         return $this->ExpiryMonth;
     }
 
-    /**
-     * @param int|null $ExpiryMonth
-     *
-     * @return InternationalPassport
-     */
     public function setExpiryMonth(?int $ExpiryMonth): InternationalPassport
     {
         $this->ExpiryMonth = $ExpiryMonth;
@@ -132,19 +102,11 @@ class InternationalPassport extends ID3IdentityObject
         return $this;
     }
 
-    /**
-     * @return int|null
-     */
     public function getExpiryYear(): ?int
     {
         return $this->ExpiryYear;
     }
 
-    /**
-     * @param int|null $ExpiryYear
-     *
-     * @return InternationalPassport
-     */
     public function setExpiryYear(?int $ExpiryYear): InternationalPassport
     {
         $this->ExpiryYear = $ExpiryYear;
@@ -152,33 +114,20 @@ class InternationalPassport extends ID3IdentityObject
         return $this;
     }
 
-    /**
-     * @param DateTime|null $expiryDate
-     *
-     * @return InternationalPassport
-     */
     public function setExpiryDate(?DateTime $expiryDate): InternationalPassport
     {
-        $this->setExpiryDay($expiryDate->format('d'));
-        $this->setExpiryMonth($expiryDate->format('m'));
-        $this->setExpiryYear($expiryDate->format('Y'));
+        $this->setExpiryDay((int)$expiryDate->format('d'));
+        $this->setExpiryMonth((int)$expiryDate->format('m'));
+        $this->setExpiryYear((int)$expiryDate->format('Y'));
 
         return $this;
     }
 
-    /**
-     * @return int|null
-     */
     public function getIssueDay(): ?int
     {
         return $this->IssueDay;
     }
 
-    /**
-     * @param int|null $IssueDay
-     *
-     * @return InternationalPassport
-     */
     public function setIssueDay(?int $IssueDay): InternationalPassport
     {
         $this->IssueDay = $IssueDay;
@@ -186,19 +135,11 @@ class InternationalPassport extends ID3IdentityObject
         return $this;
     }
 
-    /**
-     * @return int|null
-     */
     public function getIssueMonth(): ?int
     {
         return $this->IssueMonth;
     }
 
-    /**
-     * @param int|null $IssueMonth
-     *
-     * @return InternationalPassport
-     */
     public function setIssueMonth(?int $IssueMonth): InternationalPassport
     {
         $this->IssueMonth = $IssueMonth;
@@ -206,19 +147,11 @@ class InternationalPassport extends ID3IdentityObject
         return $this;
     }
 
-    /**
-     * @return int|null
-     */
     public function getIssueYear(): ?int
     {
         return $this->IssueYear;
     }
 
-    /**
-     * @param int|null $IssueYear
-     *
-     * @return InternationalPassport
-     */
     public function setIssueYear(?int $IssueYear): InternationalPassport
     {
         $this->IssueYear = $IssueYear;
@@ -226,33 +159,20 @@ class InternationalPassport extends ID3IdentityObject
         return $this;
     }
 
-    /**
-     * @param DateTime|null $issueDate
-     *
-     * @return InternationalPassport
-     */
     public function setIssueDate(?DateTime $issueDate): InternationalPassport
     {
-        $this->setIssueDay($issueDate->format('d'));
-        $this->setIssueMonth($issueDate->format('m'));
-        $this->setIssueYear($issueDate->format('Y'));
+        $this->setIssueDay((int)$issueDate->format('d'));
+        $this->setIssueMonth((int)$issueDate->format('m'));
+        $this->setIssueYear((int)$issueDate->format('Y'));
 
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getCountryOfOrigin(): ?string
     {
         return $this->CountryOfOrigin;
     }
 
-    /**
-     * @param string $CountryOfOrigin
-     *
-     * @return InternationalPassport
-     */
     public function setCountryOfOrigin(string $CountryOfOrigin): InternationalPassport
     {
         $this->CountryOfOrigin = $CountryOfOrigin;

--- a/src/Identity/Documents/InternationalPassport.php
+++ b/src/Identity/Documents/InternationalPassport.php
@@ -114,8 +114,15 @@ class InternationalPassport extends ID3IdentityObject
         return $this;
     }
 
-    public function setExpiryDate(DateTime $expiryDate): InternationalPassport
+    public function setExpiryDate(?DateTime $expiryDate): InternationalPassport
     {
+        // Set all expiry date fields to null if we're not given a valid date
+        if (!$expiryDate) {
+            $this->setExpiryDay(null)->setExpiryMonth(null)->setExpiryYear(null);
+
+            return $this;
+        }
+
         $this->setExpiryDay((int)$expiryDate->format('d'));
         $this->setExpiryMonth((int)$expiryDate->format('m'));
         $this->setExpiryYear((int)$expiryDate->format('Y'));
@@ -159,8 +166,15 @@ class InternationalPassport extends ID3IdentityObject
         return $this;
     }
 
-    public function setIssueDate(DateTime $issueDate): InternationalPassport
+    public function setIssueDate(?DateTime $issueDate): InternationalPassport
     {
+        // Set all issue date fields to null if we're not given a valid date
+        if (!$issueDate) {
+            $this->setIssueDay(null)->setIssueMonth(null)->setIssueYear(null);
+
+            return $this;
+        }
+
         $this->setIssueDay((int)$issueDate->format('d'));
         $this->setIssueMonth((int)$issueDate->format('m'));
         $this->setIssueYear((int)$issueDate->format('Y'));

--- a/src/Identity/Documents/NZ/DrivingLicence.php
+++ b/src/Identity/Documents/NZ/DrivingLicence.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ID3Global\Identity\Documents\NZ;
 
 use ID3Global\Identity\ID3IdentityObject;
@@ -7,12 +9,12 @@ use ID3Global\Identity\ID3IdentityObject;
 class DrivingLicence extends ID3IdentityObject
 {
     /**
-     * @var string|null The driver licence identifier
+     * @var string|null The driver licence identifier/number (as indicated on the physical document)
      */
     private ?string $Number = null;
 
     /**
-     * @var int|null
+     * @var int|null The driver license version (as indicated on the physical document)
      */
     private ?int $Version = null;
 
@@ -21,19 +23,11 @@ class DrivingLicence extends ID3IdentityObject
      */
     private ?string $VehicleRegistration = null;
 
-    /**
-     * @return string|null
-     */
     public function getNumber(): ?string
     {
         return $this->Number;
     }
 
-    /**
-     * @param string|null $Number
-     *
-     * @return DrivingLicence
-     */
     public function setNumber(?string $Number): DrivingLicence
     {
         $this->Number = $Number;
@@ -41,19 +35,11 @@ class DrivingLicence extends ID3IdentityObject
         return $this;
     }
 
-    /**
-     * @return int|null
-     */
     public function getVersion(): ?int
     {
         return $this->Version;
     }
 
-    /**
-     * @param int|null $Version
-     *
-     * @return DrivingLicence
-     */
     public function setVersion(?int $Version): DrivingLicence
     {
         $this->Version = $Version;
@@ -61,19 +47,11 @@ class DrivingLicence extends ID3IdentityObject
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getVehicleRegistration(): ?string
     {
         return $this->VehicleRegistration;
     }
 
-    /**
-     * @param string|null $VehicleRegistration
-     *
-     * @return DrivingLicence
-     */
     public function setVehicleRegistration(?string $VehicleRegistration): DrivingLicence
     {
         $this->VehicleRegistration = $VehicleRegistration;

--- a/src/Identity/ID3IdentityObject.php
+++ b/src/Identity/ID3IdentityObject.php
@@ -1,10 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ID3Global\Identity;
 
 class ID3IdentityObject
 {
-    public function __get($key)
+    /**
+     * Generic getter for all internal data types. A method needs to exist on the subclass to return the value. We need
+     * to suppress the DisallowedMixedTypeHint phpcs sniff as we may return a number of different things from this
+     * method (int, string, array or object).
+     *
+     * @param string $key The key to look for (e.g. 'FirstName' will need a method called 'getFirstName' to exist)
+     * @return mixed
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint
+     */
+    public function __get(string $key)
     {
         $funcName = sprintf('get%s', ucfirst($key));
 

--- a/src/Identity/Identity.php
+++ b/src/Identity/Identity.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ID3Global\Identity;
 
 use ID3Global\Identity\Address\AddressContainer;
@@ -7,31 +9,14 @@ use ID3Global\Identity\Documents\DocumentContainer;
 
 class Identity
 {
-    /**
-     * @var PersonalDetails|null
-     */
     private ?PersonalDetails $personalDetails = null;
 
-    /**
-     * @var ContactDetails|null
-     */
     private ?ContactDetails $contactDetails = null;
 
-    /**
-     * @var AddressContainer|null
-     */
     private ?AddressContainer $addresses = null;
 
-    /**
-     * @var DocumentContainer|null
-     */
     private ?DocumentContainer $identityDocuments = null;
 
-    /**
-     * @param PersonalDetails $personalDetails
-     *
-     * @return Identity
-     */
     public function setPersonalDetails(PersonalDetails $personalDetails): Identity
     {
         $this->personalDetails = $personalDetails;
@@ -44,11 +29,6 @@ class Identity
         return $this->personalDetails;
     }
 
-    /**
-     * @param ContactDetails $contactDetails
-     *
-     * @return Identity
-     */
     public function setContactDetails(ContactDetails $contactDetails): Identity
     {
         $this->contactDetails = $contactDetails;
@@ -56,19 +36,11 @@ class Identity
         return $this;
     }
 
-    /**
-     * @return ContactDetails|null
-     */
     public function getContactDetails(): ?ContactDetails
     {
         return $this->contactDetails;
     }
 
-    /**
-     * @param Address\AddressContainer $addresses
-     *
-     * @return Identity
-     */
     public function setAddresses(AddressContainer $addresses): Identity
     {
         $this->addresses = $addresses;
@@ -81,19 +53,11 @@ class Identity
         return $this->addresses;
     }
 
-    /**
-     * @return DocumentContainer|null
-     */
     public function getIdentityDocuments(): ?DocumentContainer
     {
         return $this->identityDocuments;
     }
 
-    /**
-     * @param Documents\DocumentContainer $identityDocuments
-     *
-     * @return Identity
-     */
     public function setIdentityDocuments(DocumentContainer $identityDocuments): Identity
     {
         $this->identityDocuments = $identityDocuments;

--- a/src/Identity/PersonalDetails.php
+++ b/src/Identity/PersonalDetails.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ID3Global\Identity;
 
 use DateTime;
@@ -7,60 +9,61 @@ use DateTime;
 class PersonalDetails extends ID3IdentityObject
 {
     /**
-     * @var string|null
+     * @var string|null The 'title' for this person e.g. Mr, Mrs, Dr. Can only be null when verifying a UK identity.
+     * @see https://bit.ly/3zPzUp6+
      */
     private ?string $Title = null;
 
     /**
-     * @var string|null
+     * @var string|null The first name for the specified identity. Can only be null when verifying a UK identity.
+     * @see https://bit.ly/3zPzUp6+
      */
     private ?string $Forename = null;
 
     /**
-     * @var string|null
+     * @var string|null The middle name for the specified identity. Can be null if the person has no middle name(s).
      */
     private ?string $MiddleName = null;
 
     /**
-     * @var string|null
+     * @var string|null The surname/last name for the specified identity. Can only be null when verifying a UK identity.
      */
     private ?string $Surname = null;
 
     /**
-     * @var string|null
+     * @var string|null The gender for the specified identity. Can be 'Female', 'Male', 'Unknown' or 'Unspecified'. Can
+     * only be null when verifying a UK identity.
      */
     private ?string $Gender = null;
 
     /**
-     * @var DateTime|null
+     * @var DateTime|null The full date of birth for the specified identity.
      */
     private ?DateTime $dateOfBirth = null;
 
     /**
-     * @var int|null
+     * @var int|null The day (e.g. 1, 15, 31) the person was born on (similar to $this->dateOfBirth, but just the value
+     * as the ID3global API expects it in a singluar field).
      */
     private ?int $DOBDay = null;
 
     /**
-     * @var int|null
+     * @var int|null The month (e.g. 1, 5, 12) the person was born in (similar to $this->dateOfBirth, but just the value
+     * as the ID3global API expects it in a singluar field).
      */
     private ?int $DOBMonth = null;
 
     /**
-     * @var int|null
+     * @var int|null The year (e.g. 1995) the person was born in (similar to $this->dateOfBirth, but just the value as
+     * the ID3global API expects it in a singluar field).
      */
     private ?int $DOBYear = null;
 
     /**
-     * @var string|null
+     * @var string|null The country of birth for the specified identity (e.g. 'New Zealand', 'Austria' etc)
      */
     private ?string $CountryOfBirth = null;
 
-    /**
-     * @param string|null $title
-     *
-     * @return PersonalDetails
-     */
     public function setTitle(?string $title): PersonalDetails
     {
         $this->Title = $title;
@@ -68,11 +71,6 @@ class PersonalDetails extends ID3IdentityObject
         return $this;
     }
 
-    /**
-     * @param string|null $forename
-     *
-     * @return PersonalDetails
-     */
     public function setForename(?string $forename): PersonalDetails
     {
         $this->Forename = $forename;
@@ -80,11 +78,6 @@ class PersonalDetails extends ID3IdentityObject
         return $this;
     }
 
-    /**
-     * @param string|null $middleName
-     *
-     * @return PersonalDetails
-     */
     public function setMiddleName(?string $middleName): PersonalDetails
     {
         $this->MiddleName = $middleName;
@@ -92,11 +85,6 @@ class PersonalDetails extends ID3IdentityObject
         return $this;
     }
 
-    /**
-     * @param string|null $surname
-     *
-     * @return PersonalDetails
-     */
     public function setSurname(?string $surname): PersonalDetails
     {
         $this->Surname = $surname;
@@ -104,11 +92,6 @@ class PersonalDetails extends ID3IdentityObject
         return $this;
     }
 
-    /**
-     * @param string|null $gender
-     *
-     * @return PersonalDetails
-     */
     public function setGender(?string $gender): PersonalDetails
     {
         $this->Gender = $gender;
@@ -117,30 +100,27 @@ class PersonalDetails extends ID3IdentityObject
     }
 
     /**
-     * @param DateTime|null $birthday
+     * Sets the date of birth for the specified identity. Populates both the 'dateOfBirth' (DateTime) field, as well as
+     * the individual DOBDay, DOBMonth and DOBYear fields that are actually submitted to the ID3global API.
      *
-     * @return PersonalDetails
+     * @param DateTime|null $birthday The date of birth for the specified identity.
+     * @return self
      */
     public function setDateOfBirth(?DateTime $birthday): PersonalDetails
     {
-        if ($birthday == null) {
+        if ($birthday === null) {
             return $this;
         }
 
         $this->dateOfBirth = $birthday;
 
-        $this->DOBDay = $birthday->format('d') ?? null;
-        $this->DOBMonth = $birthday->format('m') ?? null;
-        $this->DOBYear = $birthday->format('Y') ?? null;
+        $this->DOBDay = (int)$birthday->format('d') ?? null;
+        $this->DOBMonth = (int)$birthday->format('m') ?? null;
+        $this->DOBYear = (int)$birthday->format('Y') ?? null;
 
         return $this;
     }
 
-    /**
-     * @param string|null $CountryOfBirth
-     *
-     * @return PersonalDetails
-     */
     public function setCountryOfBirth(?string $CountryOfBirth): PersonalDetails
     {
         $this->CountryOfBirth = $CountryOfBirth;
@@ -148,81 +128,51 @@ class PersonalDetails extends ID3IdentityObject
         return $this;
     }
 
-    /**
-     * @return string|null
-     */
     public function getTitle(): ?string
     {
         return $this->Title;
     }
 
-    /**
-     * @return string|null
-     */
     public function getForename(): ?string
     {
         return $this->Forename;
     }
 
-    /**
-     * @return string|null
-     */
     public function getMiddleName(): ?string
     {
         return $this->MiddleName;
     }
 
-    /**
-     * @return string|null
-     */
     public function getSurname(): ?string
     {
         return $this->Surname;
     }
 
-    /**
-     * @return string|null
-     */
     public function getGender(): ?string
     {
         return $this->Gender;
     }
 
-    /**
-     * @return DateTime|null
-     */
     public function getDateOfBirth(): ?DateTime
     {
         return $this->dateOfBirth;
     }
 
-    /**
-     * @return int|null
-     */
     public function getDOBDay(): ?int
     {
         return $this->DOBDay;
     }
 
-    /**
-     * @return int|null
-     */
     public function getDOBMonth(): ?int
     {
         return $this->DOBMonth;
     }
 
-    /**
-     * @return int|null
-     */
     public function getDOBYear(): ?int
     {
         return $this->DOBYear;
     }
 
-    /**
-     * @return string|null
-     */
     public function getCountryOfBirth(): ?string
     {
         return $this->CountryOfBirth;

--- a/src/Service/GlobalAuthenticationService.php
+++ b/src/Service/GlobalAuthenticationService.php
@@ -81,7 +81,7 @@ class GlobalAuthenticationService extends ID3BaseService
      * you can pass these in here, or call ->setSoapOptions() after constructing the object.
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification
      */
-    public function __construct(?GlobalAuthenticationGateway $gateway, array $soapOptions = [])
+    public function __construct(?GlobalAuthenticationGateway $gateway = null, array $soapOptions = [])
     {
         $this->gateway = $gateway;
         $this->soapOptions = $soapOptions;

--- a/src/Service/ID3BaseService.php
+++ b/src/Service/ID3BaseService.php
@@ -1,22 +1,24 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ID3Global\Service;
 
 abstract class ID3BaseService
 {
     /**
      * @var bool Set to true to use the ID3 'pilot' (aka. staging or test) site for all API calls. By default, with this
-     *           value set to false all API calls are made against the live API.
+     * value set to false all API calls are made against the live API.
      */
     private bool $pilotSiteEnabled = false;
 
     /**
-     * @var string
+     * @var string The API username used to authenticate with the ID3global API.
      */
     private string $apiUsername;
 
     /**
-     * @var string
+     * @var string The API username used to authenticate with the ID3global API.
      */
     private string $apiPassword;
 
@@ -25,12 +27,8 @@ abstract class ID3BaseService
         return (bool) $this->pilotSiteEnabled;
     }
 
-    public function setPilotSiteEnabled($bool = true): ID3BaseService
+    public function setPilotSiteEnabled(bool $bool = true): ID3BaseService
     {
-        if (!is_bool($bool)) {
-            $bool = false;
-        }
-
         $this->pilotSiteEnabled = $bool;
 
         return $this;
@@ -41,7 +39,7 @@ abstract class ID3BaseService
         return $this->apiUsername;
     }
 
-    public function setApiUsername($username): ID3BaseService
+    public function setApiUsername(string $username): ID3BaseService
     {
         $this->apiUsername = $username;
 
@@ -53,7 +51,7 @@ abstract class ID3BaseService
         return $this->apiPassword;
     }
 
-    public function setApiPassword($password): ID3BaseService
+    public function setApiPassword(string $password): ID3BaseService
     {
         $this->apiPassword = $password;
 

--- a/src/Stubs/Gateway/GlobalAuthenticationGatewayFake.php
+++ b/src/Stubs/Gateway/GlobalAuthenticationGatewayFake.php
@@ -57,8 +57,12 @@ class GlobalAuthenticationGatewayFake extends GlobalAuthenticationGateway
      * @inheritDoc
      * @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter
      */
-    public function AuthenticateSP(string $pId, int $pVer, ?string $customerReference, Identity $identity): stdClass
-    {
+    public function AuthenticateSP(
+        string $profileId,
+        int $profileVersion,
+        ?string $customerReference,
+        Identity $identity
+    ): stdClass {
         $result = 'O:8:"stdClass":1:{s:20:"AuthenticateSPResult";O:8:"stdClass":12:{s:16:"AuthenticationID";s:36:"'
             . 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";s:9:"Timestamp";s:33:"2016-01-01T00:00:00.0000000+01:00";s:11:"'
             . 'CustomerRef";s:%d:"%s";s:9:"ProfileID";s:%d:"%s";s:11:"ProfileName";s:15:"Default Profile";s:14:"'
@@ -70,9 +74,9 @@ class GlobalAuthenticationGatewayFake extends GlobalAuthenticationGateway
             $result,
             $customerReference ? strlen($customerReference) : 0,
             $customerReference,
-            strlen($pId),
-            $pId,
-            $pVer,
+            strlen($profileId),
+            $profileId,
+            $profileVersion,
             $this->score,
             strlen($this->bandText),
             $this->bandText

--- a/src/Stubs/Gateway/GlobalAuthenticationGatewayFake.php
+++ b/src/Stubs/Gateway/GlobalAuthenticationGatewayFake.php
@@ -1,45 +1,42 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ID3Global\Stubs\Gateway;
 
 use ID3Global\Gateway\GlobalAuthenticationGateway;
 use ID3Global\Identity\Identity;
+use stdClass;
 
 class GlobalAuthenticationGatewayFake extends GlobalAuthenticationGateway
 {
-    /**
-     * @var string A BandText value returned by the ID3global API when this identity passed verification, according to
-     *             the selected profile.
-     */
-    const IDENTITY_BAND_PASS = 'PASS';
+    public const IDENTITY_BAND_PASS = 'PASS';
+
+    public const IDENTITY_BAND_REFER = 'REFER';
+
+    public const IDENTITY_BAND_ALERT = 'ALERT';
 
     /**
-     * @var string A BandText value returned by the ID3global API when this identity needs additional referral,
-     *             according to the selected profile.
+     * @var string Allows overriding of the BandText returned from the fake AuthenticateSP call to ensure tests can
+     * influence the code paths that the GlobalAuthenticationService class under test would take (e.g. returning an
+     * exception or similar).
      */
-    const IDENTITY_BAND_REFER = 'REFER';
-
-    /**
-     * @var string A BandText value returned by the ID3global API when this identity has a significant issue, according
-     *             to the selected profile.
-     */
-    const IDENTITY_BAND_ALERT = 'ALERT';
-
     private string $bandText = self::IDENTITY_BAND_PASS;
 
     private int $score = 3000;
 
+    /**
+     * @inheritDoc
+     */
     public function __construct($username, $password, $soapClientOptions = [], $usePilotSite = false)
     {
         parent::__construct($username, $password, $soapClientOptions, $usePilotSite);
     }
 
     /**
-     * @param string $bandText
-     *
-     * @return GlobalAuthenticationGatewayFake
+     * Sets a custom BandText to be returned whenever AuthenticateSP is called.
      */
-    public function setBandText(string $bandText): GlobalAuthenticationGatewayFake
+    public function setBandText(string $bandText): self
     {
         $this->bandText = $bandText;
 
@@ -47,26 +44,35 @@ class GlobalAuthenticationGatewayFake extends GlobalAuthenticationGateway
     }
 
     /**
-     * @param int $score
-     *
-     * @return GlobalAuthenticationGatewayFake
+     * Sets a custom Score to be returned whenever AuthenticateSP is called.
      */
-    public function setScore(int $score): GlobalAuthenticationGatewayFake
+    public function setScore(int $score): self
     {
         $this->score = $score;
 
         return $this;
     }
 
-    public function AuthenticateSP(string $profileID, int $profileVersion, ?string $customerReference, Identity $identity)
+    /**
+     * @inheritDoc
+     * @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter
+     */
+    public function AuthenticateSP(string $pId, int $pVer, ?string $customerReference, Identity $identity): stdClass
     {
+        $result = 'O:8:"stdClass":1:{s:20:"AuthenticateSPResult";O:8:"stdClass":12:{s:16:"AuthenticationID";s:36:"'
+            . 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";s:9:"Timestamp";s:33:"2016-01-01T00:00:00.0000000+01:00";s:11:"'
+            . 'CustomerRef";s:%d:"%s";s:9:"ProfileID";s:%d:"%s";s:11:"ProfileName";s:15:"Default Profile";s:14:"'
+            . 'ProfileVersion";i:%d;s:15:"ProfileRevision";i:1;s:12:"ProfileState";s:9:"Effective";s:11:"ResultCodes";'
+            . 'O:8:"stdClass":1:{s:26:"GlobalItemCheckResultCodes";a:0:{}}s:5:"Score";i:%d;s:8:"BandText";s:%d:"%s";s:7'
+            . ':"Country";s:11:"New Zealand";}}';
+
         return unserialize(sprintf(
-            'O:8:"stdClass":1:{s:20:"AuthenticateSPResult";O:8:"stdClass":12:{s:16:"AuthenticationID";s:36:"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";s:9:"Timestamp";s:33:"2016-01-01T00:00:00.0000000+01:00";s:11:"CustomerRef";s:%d:"%s";s:9:"ProfileID";s:%d:"%s";s:11:"ProfileName";s:15:"Default Profile";s:14:"ProfileVersion";i:%d;s:15:"ProfileRevision";i:1;s:12:"ProfileState";s:9:"Effective";s:11:"ResultCodes";O:8:"stdClass":1:{s:26:"GlobalItemCheckResultCodes";a:0:{}}s:5:"Score";i:%d;s:8:"BandText";s:%d:"%s";s:7:"Country";s:11:"New Zealand";}}',
-            strlen($customerReference),
+            $result,
+            $customerReference ? strlen($customerReference) : 0,
             $customerReference,
-            strlen($profileID),
-            $profileID,
-            $profileVersion,
+            strlen($pId),
+            $pId,
+            $pVer,
             $this->score,
             strlen($this->bandText),
             $this->bandText

--- a/tests/Gateway/Request/AuthenticateSPRequestTest.php
+++ b/tests/Gateway/Request/AuthenticateSPRequestTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ID3Global\Tests\Gateway\Request;
 
 use DateTime;
@@ -19,18 +21,11 @@ use stdClass;
 class AuthenticateSPRequestTest extends TestCase
 {
     /**
-     * @var Identity
+     * @var Identity A blank Identity object to be updated during test cases as required
      */
     private Identity $identity;
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->identity = new Identity();
-    }
-
-    public function testStandardParams()
+    public function testStandardParams(): void
     {
         $version = new stdClass();
         $version->Version = 1;
@@ -44,7 +39,7 @@ class AuthenticateSPRequestTest extends TestCase
         $this->assertEquals('X', $r->getCustomerReference());
     }
 
-    public function testPersonalDetails()
+    public function testPersonalDetails(): void
     {
         $birthday = DateTime::createFromFormat('Y-m-d', '1973-04-05');
 
@@ -72,7 +67,7 @@ class AuthenticateSPRequestTest extends TestCase
         $this->assertSame('US', $test->CountryOfBirth);
     }
 
-    public function testContactDetails()
+    public function testContactDetails(): void
     {
         $landTelephone = new ContactDetails\PhoneNumber();
         $landTelephone->setNumber('1(800) 786-1410');
@@ -91,7 +86,7 @@ class AuthenticateSPRequestTest extends TestCase
         $this->assertSame('1(800) 786-1410', $test->LandTelephone->Number);
     }
 
-    public function testInternationalPassport()
+    public function testInternationalPassport(): void
     {
         $issueDate = DateTime::createFromFormat('Y-m-d', '2020-01-02');
         $expiryDate = DateTime::createFromFormat('Y-m-d', '2030-01-02');
@@ -122,7 +117,7 @@ class AuthenticateSPRequestTest extends TestCase
         $this->assertSame('Azerbaijan', $test->CountryOfOrigin);
     }
 
-    public function testFixedLengthAddress()
+    public function testFixedLengthAddress(): void
     {
         $address = new FixedFormatAddress();
         $address
@@ -161,7 +156,7 @@ class AuthenticateSPRequestTest extends TestCase
         $this->assertSame('10118', $test->ZipPostcode);
     }
 
-    public function testFreeFormatAddress()
+    public function testFreeFormatAddress(): void
     {
         $address = new FreeFormatAddress();
 
@@ -197,7 +192,7 @@ class AuthenticateSPRequestTest extends TestCase
         $this->assertSame('NZ', $test->AddressLine8);
     }
 
-    public function testNZDrivingLicence()
+    public function testNZDrivingLicence(): void
     {
         $licence = new DrivingLicence();
 
@@ -217,5 +212,12 @@ class AuthenticateSPRequestTest extends TestCase
         $this->assertSame('DI123456', $test->NewZealand->DrivingLicence->Number);
         $this->assertSame(123, $test->NewZealand->DrivingLicence->Version);
         $this->assertSame('ABC123', $test->NewZealand->DrivingLicence->VehicleRegistration);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->identity = new Identity();
     }
 }

--- a/tests/Service/GlobalAuthenticationServiceTest.php
+++ b/tests/Service/GlobalAuthenticationServiceTest.php
@@ -70,15 +70,20 @@ class GlobalAuthenticationServiceTest extends TestCase
 
     /**
      * @dataProvider fakeResponses
-     * @param string $pId Profile ID value
-     * @param int $pVer Profile Version value
-     * @param string $custRef Customer reference submitted
+     * @param string $profileId Profile ID value
+     * @param int $profileVersion Profile Version value
+     * @param string $customerReference Customer reference submitted
      * @param string $bandText The BandText to return from the fake gateway
      * @param int $score The score to return from the fake gateway
      * @throws IdentityVerificationFailureException
      */
-    public function testFakeResponses(string $pId, int $pVer, string $custRef, string $bandText, int $score): void
-    {
+    public function testFakeResponses(
+        string $profileId,
+        int $profileVersion,
+        string $customerReference,
+        string $bandText,
+        int $score
+    ): void {
         // Arrange
         $this->fakeGateway->setBandText($bandText)->setScore($score);
 
@@ -86,18 +91,18 @@ class GlobalAuthenticationServiceTest extends TestCase
 
         // Act
         $result = $this->service
-            ->setProfileId($pId)
-            ->setProfileVersion($pVer)
-            ->verifyIdentity($identity, $custRef);
+            ->setProfileId($profileId)
+            ->setProfileVersion($profileVersion)
+            ->verifyIdentity($identity, $customerReference);
 
         $response = $this->service->getLastVerifyIdentityResponse();
 
         // Assert
         $this->assertSame($bandText, $result);
         $this->assertSame($score, $response->AuthenticateSPResult->Score);
-        $this->assertSame($pId, $response->AuthenticateSPResult->ProfileID);
-        $this->assertSame($pVer, $response->AuthenticateSPResult->ProfileVersion);
-        $this->assertSame($custRef, $response->AuthenticateSPResult->CustomerRef);
+        $this->assertSame($profileId, $response->AuthenticateSPResult->ProfileID);
+        $this->assertSame($profileVersion, $response->AuthenticateSPResult->ProfileVersion);
+        $this->assertSame($customerReference, $response->AuthenticateSPResult->CustomerRef);
     }
 
     public function testNotSettingProfileIdThrows(): void


### PR DESCRIPTION
Add phpcs linting and code coverage via codecov.io. Linting supports both PHP 7.4 and 8.0.

**Changes:**
- No longer catch exceptions in GlobalAuthenticationService->verifyIdentity() - we just immediately re-threw it anyway
- Allow both $gateway and $soapOptions arguments to GlobalAuthenticationService constructor to be optional (backwards compatibility with 0.2, and make ->setApiUsername() etc actually useful)
- Add return type hints where-ever they were missing
- Add phpdocs where-ever they were missing
- Don't pass `null` into SoapVar object creation as it should be a string
- Lots of other changes to comply with linting rules (no significant code changes)
- Ensure all files are using strict_types=1

**Tests & linting:**
- Include strict slevomat/coding-standard module for additional phpcs checks
- Configure phpcs.xml.dist with specific linting rules (based on PSR-12 and slevomat/coding-standard defaults, with minor tweaks)
- Run full linting pass
- Approx ~150 changes to comply with linting rules
- Add code coverage to phpunit run
- Via GitHub Actions, upload code coverage information to codecov.io
- Include php-parallel-lint and phpcs to GitHub Actions workflow, rename from phpunit.yml to run-tests.yml
- Allow BandText to be changed during test runs and add a new test for it

**Documentation:**
- Move the full PHP code example from README.md into new docs/full-code-example.md and link through
- Add new documentation covering various module settings to README.md
- Update full code example with descriptions for key classes, and remove outdated info

**Minor:**
- Update .gitignore to ignore new .artifacts directory and re-order alphabetically